### PR TITLE
SC: `cdt-clang` submodule -- Add support for `call` attribute and `call` dispatcher

### DIFF
--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -1927,6 +1927,7 @@ public:
   bool isEosioWasmImport()const;
   bool isEosioWasmAction()const;
   std::string getEosioWasmAction()const;
+  std::string getEosioWasmCall()const;
   bool isEosioWasmNotify()const;
   std::string getEosioWasmNotify()const;
 

--- a/include/clang/AST/DeclCXX.h
+++ b/include/clang/AST/DeclCXX.h
@@ -733,11 +733,13 @@ public:
   bool isEosioIgnore() const { return hasAttr<EosioIgnoreAttr>(); }
   bool hasEosioRicardian() const { return hasAttr<EosioRicardianAttr>(); }
   bool isEosioReadOnly() const { return hasAttr<EosioReadOnlyAttr>(); }
+  bool isEosioCall() const { return hasAttr<EosioCallAttr>(); }
   EosioActionAttr* getEosioActionAttr() const { return getAttr<EosioActionAttr>(); }
   EosioTableAttr*  getEosioTableAttr() const { return getAttr<EosioTableAttr>(); }
   EosioContractAttr*  getEosioContractAttr() const { return getAttr<EosioContractAttr>(); }
   EosioRicardianAttr*  getEosioRicardianAttr() const { return getAttr<EosioRicardianAttr>(); }
   EosioReadOnlyAttr* getEosioReadOnlyAttr() const { return getAttr<EosioReadOnlyAttr>(); }
+  EosioCallAttr* getEosioCallAttr() const { return getAttr<EosioCallAttr>(); }
 
   CXXRecordDecl *getCanonicalDecl() override {
     return cast<CXXRecordDecl>(RecordDecl::getCanonicalDecl());
@@ -2155,11 +2157,13 @@ public:
   bool isEosioContract() const { return hasAttr<EosioContractAttr>(); }
   bool hasEosioRicardian() const { return hasAttr<EosioRicardianAttr>(); }
   bool isEosioReadOnly() const { return hasAttr<EosioReadOnlyAttr>(); }
+  bool isEosioCall() const { return hasAttr<EosioCallAttr>(); }
   EosioActionAttr* getEosioActionAttr() const { return getAttr<EosioActionAttr>(); }
   EosioNotifyAttr* getEosioNotifyAttr() const { return getAttr<EosioNotifyAttr>(); }
   EosioContractAttr* getEosioContractAttr() const { return getAttr<EosioContractAttr>(); }
   EosioRicardianAttr* getEosioRicardianAttr() const { return getAttr<EosioRicardianAttr>(); }
   EosioReadOnlyAttr* getEosioReadOnlyAttr() const { return getAttr<EosioReadOnlyAttr>(); }
+  EosioCallAttr* getEosioCallAttr() const { return getAttr<EosioCallAttr>(); }
 
   /// Returns true if the given operator is implicitly static in a record
   /// context.

--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -1063,6 +1063,13 @@ def EosioWasmAction : InheritableAttr {
    let Documentation = [EosioWasmImportDocs];
 }
 
+def EosioWasmCall : InheritableAttr {
+   let Spellings = [CXX11<"eosio", "wasm_call">, GNU<"eosio_wasm_call">];
+   let Args = [StringArgument<"name", 1>];
+   let Subjects = SubjectList<[Function]>;
+   let Documentation = [EosioWasmImportDocs];
+}
+
 def EosioWasmNotify : InheritableAttr {
    let Spellings = [CXX11<"eosio", "wasm_notify">, GNU<"eosio_wasm_notify">];
    let Args = [StringArgument<"name", 1>];
@@ -1094,6 +1101,13 @@ def EosioAction : InheritableAttr {
    let Args = [StringArgument<"name", 1>];
    let Subjects = SubjectList<[CXXRecord, CXXMethod]>;
    let Documentation = [EosioActionDocs];
+}
+
+def EosioCall : InheritableAttr {
+   let Spellings = [CXX11<"eosio", "call">, GNU<"eosio_call">];
+   let Args = [StringArgument<"name", 1>];
+   let Subjects = SubjectList<[CXXRecord, CXXMethod]>;
+   let Documentation = [EosioCallDocs];
 }
 
 def EosioReadOnly : InheritableAttr {

--- a/include/clang/Basic/AttrDocs.td
+++ b/include/clang/Basic/AttrDocs.td
@@ -1043,6 +1043,13 @@ The ``eosio::read_only`` attribute marks a method as being a read-only action.
   }];
 }
 
+def EosioCallDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``eosio::call`` attribute marks a method as being a sync call function.
+  }];
+}
+
 def EosioTableDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4583,6 +4583,7 @@ bool FunctionDecl::isEosioWasmEntry()const { return hasAttr<EosioWasmEntryAttr>(
 bool FunctionDecl::isEosioWasmImport()const { return hasAttr<EosioWasmImportAttr>(); }
 bool FunctionDecl::isEosioWasmAction()const { return hasAttr<EosioWasmActionAttr>(); }
 std::string FunctionDecl::getEosioWasmAction()const { return getAttr<EosioWasmActionAttr>()->getName(); }
+std::string FunctionDecl::getEosioWasmCall()const { return getAttr<EosioWasmCallAttr>()->getName(); }
 bool FunctionDecl::isEosioWasmNotify()const { return hasAttr<EosioWasmNotifyAttr>(); }
 std::string FunctionDecl::getEosioWasmNotify()const { return getAttr<EosioWasmNotifyAttr>()->getName(); }
 

--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -2996,6 +2996,7 @@ llvm::Constant *CodeGenModule::GetOrCreateLLVMFunction(
   bool isWasmEntry  = false;
   bool isWasmABI    = false;
   bool isWasmAction = false;
+  bool isWasmCall   = false;
   bool isWasmNotify = false;
 
   // Any attempts to use a MultiVersion function should result in retrieving
@@ -3009,6 +3010,8 @@ llvm::Constant *CodeGenModule::GetOrCreateLLVMFunction(
         isWasmABI = true;
      if (FD->hasAttr<EosioWasmActionAttr>())
         isWasmAction = true;
+     if (FD->hasAttr<EosioWasmCallAttr>())
+        isWasmCall = true;
      if (FD->hasAttr<EosioWasmNotifyAttr>())
         isWasmNotify = true;
 
@@ -3145,6 +3148,10 @@ llvm::Constant *CodeGenModule::GetOrCreateLLVMFunction(
   if (isWasmAction)
      if (const FunctionDecl *FD = cast_or_null<FunctionDecl>(D)) {
         F->addFnAttr("eosio_wasm_action", FD->getEosioWasmAction().c_str());
+     }
+  if (isWasmCall)
+     if (const FunctionDecl *FD = cast_or_null<FunctionDecl>(D)) {
+        F->addFnAttr("eosio_wasm_call", FD->getEosioWasmCall().c_str());
      }
   if (isWasmNotify)
      if (const FunctionDecl *FD = cast_or_null<FunctionDecl>(D)) {

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -482,6 +482,19 @@ static void handleEosioReadOnlyAttribute(Sema &S, Decl *D, const ParsedAttr &AL)
                  EosioReadOnlyAttr(AL.getRange(), S.Context, AL.getAttributeSpellingListIndex()));
 }
 
+static void handleEosioCallAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {
+  // Handle the cases where the attribute has a text message.
+  StringRef Str;
+  if (AL.isArgExpr(0) && AL.getArgAsExpr(0) &&
+      !S.checkStringLiteralArgumentAttr(AL, 0, Str)) {
+     return;
+  }
+
+  D->addAttr(::new (S.Context)
+                 EosioCallAttr(AL.getRange(), S.Context, Str,
+                               AL.getAttributeSpellingListIndex()));
+}
+
 static void handleEosioTableAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {
   // Handle the cases where the attribute has a text message.
   StringRef Str;
@@ -6747,6 +6760,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
   case ParsedAttr::AT_EosioAction:
     handleEosioActionAttribute(S, D, AL);
+    break;
+  case ParsedAttr::AT_EosioCall:
+    handleEosioCallAttribute(S, D, AL);
     break;
   case ParsedAttr::AT_EosioReadOnly:
     handleEosioReadOnlyAttribute(S, D, AL);


### PR DESCRIPTION
Add `call` attribute as in
```
   [[eosio::call]]
   uint32_t callee() {
      return 0;
   }

```

And add necessary plumbing (`eosio_wasm_call`) for `call` dispatcher, which is to be used in future PRs.

Resolves https://github.com/AntelopeIO/cdt/issues/347