### PR TITLE
SC: llvm-clang submodule -- Support generating sync_call entry point function

### DIFF
--- a/include/clang/AST/Decl.h
+++ b/include/clang/AST/Decl.h
@@ -1926,6 +1926,7 @@ public:
   bool isEosioWasmEntry()const;
   bool isEosioWasmImport()const;
   bool isEosioWasmAction()const;
+  bool isEosioWasmCall()const;
   std::string getEosioWasmAction()const;
   std::string getEosioWasmCall()const;
   bool isEosioWasmNotify()const;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4582,6 +4582,7 @@ std::string FunctionDecl::getWasmABI()const { return getAttr<EosioWasmABIAttr>()
 bool FunctionDecl::isEosioWasmEntry()const { return hasAttr<EosioWasmEntryAttr>(); }
 bool FunctionDecl::isEosioWasmImport()const { return hasAttr<EosioWasmImportAttr>(); }
 bool FunctionDecl::isEosioWasmAction()const { return hasAttr<EosioWasmActionAttr>(); }
+bool FunctionDecl::isEosioWasmCall()const { return hasAttr<EosioWasmCallAttr>(); }
 std::string FunctionDecl::getEosioWasmAction()const { return getAttr<EosioWasmActionAttr>()->getName(); }
 std::string FunctionDecl::getEosioWasmCall()const { return getAttr<EosioWasmCallAttr>()->getName(); }
 bool FunctionDecl::isEosioWasmNotify()const { return hasAttr<EosioWasmNotifyAttr>(); }

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -453,6 +453,18 @@ static void handleEosioWasmActionAttribute(Sema &S, Decl *D, const ParsedAttr &A
                                 AL.getAttributeSpellingListIndex()));
 }
 
+static void handleEosioWasmCallAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {
+  // Handle the cases where the attribute has a text message.
+  StringRef Str;
+  if (AL.isArgExpr(0) && AL.getArgAsExpr(0) &&
+      !S.checkStringLiteralArgumentAttr(AL, 0, Str))
+    return;
+
+  D->addAttr(::new (S.Context)
+                 EosioWasmCallAttr(AL.getRange(), S.Context, Str,
+                                   AL.getAttributeSpellingListIndex()));
+}
+
 static void handleEosioWasmNotifyAttribute(Sema &S, Decl *D, const ParsedAttr &AL) {
   // Handle the cases where the attribute has a text message.
   StringRef Str;
@@ -6775,6 +6787,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
     break;
   case ParsedAttr::AT_EosioWasmAction:
     handleEosioWasmActionAttribute(S, D, AL);
+    break;
+  case ParsedAttr::AT_EosioWasmCall:
+    handleEosioWasmCallAttribute(S, D, AL);
     break;
   case ParsedAttr::AT_EosioWasmNotify:
     handleEosioWasmNotifyAttribute(S, D, AL);


### PR DESCRIPTION
Implement necessary changes in `llvm-clang` submodule to support generating sync_call entry point function.